### PR TITLE
Update python_version 3.13 phase 1 and 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,11 @@ repos:
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
+  - repo: https://github.com/phantomcyber/soar-app-linter
+    rev: 0.1.0
+    hooks:
+      - id: soar-app-linter
+        args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22
     hooks:
@@ -55,7 +60,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.0.4
+    rev: v2.0.9
     hooks:
       - id: build-docs
         language: python

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # ForeScout CounterACT
 
-Publisher: Splunk \
-Connector Version: 2.0.6 \
-Product Vendor: ForeScout \
-Product Name: CounterACT \
+Publisher: Splunk <br>
+Connector Version: 2.0.6 <br>
+Product Vendor: ForeScout <br>
+Product Name: CounterACT <br>
 Minimum Product Version: 6.1.1
 
 This app implements various network access control actions for ForeScout
@@ -43,21 +43,21 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
-[list hosts](#action-list-hosts) - List hosts in CounterACT \
-[list policies](#action-list-policies) - List policies in CounterACT \
-[get device info](#action-get-device-info) - Get the properties of a host \
-[get sessions](#action-get-sessions) - Get active sessions in CounterACT \
-[install firewall](#action-install-firewall) - Install a virtual firewall with a property \
-[delete property](#action-delete-property) - Delete a property of a host \
-[update property](#action-update-property) - Update a property of a host \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
+[list hosts](#action-list-hosts) - List hosts in CounterACT <br>
+[list policies](#action-list-policies) - List policies in CounterACT <br>
+[get device info](#action-get-device-info) - Get the properties of a host <br>
+[get sessions](#action-get-sessions) - Get active sessions in CounterACT <br>
+[install firewall](#action-install-firewall) - Install a virtual firewall with a property <br>
+[delete property](#action-delete-property) - Delete a property of a host <br>
+[update property](#action-update-property) - Update a property of a host <br>
 [update list](#action-update-list) - Update a list by adding, deleting, or deleting all values from it
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -72,7 +72,7 @@ No Output
 
 List hosts in CounterACT
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 This action requires Web API credential in asset configuration.
@@ -100,7 +100,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 List policies in CounterACT
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 This action requires Web API credential in asset configuration.
@@ -129,7 +129,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Get the properties of a host
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 One of the parameters (host_id, host_ip, or host_mac) is required and the first to be provided is used (in that order). This action requires Web API credential in asset configuration.
@@ -196,7 +196,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Get active sessions in CounterACT
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 This action requires Web API credential in asset configuration.
@@ -229,7 +229,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Install a virtual firewall with a property
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 This action requires DEX credential in asset configuration.
@@ -267,7 +267,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Delete a property of a host
 
-Type: **correct** \
+Type: **correct** <br>
 Read only: **False**
 
 This action requires DEX credential in asset configuration.
@@ -302,7 +302,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Update a property of a host
 
-Type: **correct** \
+Type: **correct** <br>
 Read only: **False**
 
 This action requires DEX credential in asset configuration.<p>The created new host will be only seen on UI when the host value is in the range of IP segment configured in ForeScout CounterACT.</p><p>The property_name field is the Property Tag field of Property created in CounterACT. This action won’t support composite type of property.</p>
@@ -342,7 +342,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Update a list by adding, deleting, or deleting all values from it
 
-Type: **correct** \
+Type: **correct** <br>
 Read only: **False**
 
 This action requires DEX credential in asset configuration.

--- a/forescoutcounteract.json
+++ b/forescoutcounteract.json
@@ -16,7 +16,7 @@
     "main_module": "forescoutcounteract_connector.py",
     "min_phantom_version": "6.1.1",
     "app_wizard_version": "1.0.0",
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "fips_compliant": true,
     "latest_tested_versions": [
         "On-Prem, v8.2.2"

--- a/forescoutcounteract.json
+++ b/forescoutcounteract.json
@@ -1162,7 +1162,7 @@
         {
             "action": "update property",
             "description": "Update a property of a host",
-            "verbose": "This action requires DEX credential in asset configuration.<p>The created new host will be only seen on UI when the host value is in the range of IP segment configured in ForeScout CounterACT.</p><p>The property_name field is the Property Tag field of Property created in CounterACT. This action won’t support composite type of property.</p>",
+            "verbose": "This action requires DEX credential in asset configuration.<p>The created new host will be only seen on UI when the host value is in the range of IP segment configured in ForeScout CounterACT.</p><p>The property_name field is the Property Tag field of Property created in CounterACT. This action won\u2019t support composite type of property.</p>",
             "type": "correct",
             "identifier": "update_property",
             "read_only": false,
@@ -1458,5 +1458,11 @@
             },
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -6,3 +6,4 @@
 * chore(ci): update pre-commit config
 * Resolved app issues related to Python 3.13 upgrade
 * Remove beautifulsoup4 from requirements.txt
+* Update Python version for 3.13

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,9 +1,3 @@
 **Unreleased**
-* Update Python dependencies for vulnerabilities, package updates, and platform built-in removals
 * Update Python dependencies for Python 3.13 support
-* Update NOTICE file with updated dependencies
-* Apply pre-commit fixes
-* chore(ci): update pre-commit config
-* Resolved app issues related to Python 3.13 upgrade
-* Remove beautifulsoup4 from requirements.txt
 * Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13 for phase 1 and 2
- Replace `.pre-commit-config.yaml` with latest template from dev-cicd-tools

[_Created by Sourcegraph batch change `grokas-splunk/python-versions-3.13-phase1and2`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/python-versions-3.13-phase1and2)